### PR TITLE
Streamline MIRA integration

### DIFF
--- a/demo/ASKEM-Simple-Walkthrough-v1.ipynb
+++ b/demo/ASKEM-Simple-Walkthrough-v1.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "07b8203a",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-29T20:21:52.240018Z",
@@ -16,7 +15,6 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "6b40bf72",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-10-02T20:34:01.110612Z",
@@ -56,7 +54,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31ad7a9d",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-29T20:22:37.812137Z",
@@ -71,7 +68,6 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "dc0cd385",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-10-02T20:34:04.520143Z",
@@ -100,7 +96,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b4c8332",
    "metadata": {},
    "source": [
     "# Demo Functions"
@@ -109,7 +104,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eaeff9dc",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-10-02T20:34:06.638391Z",
@@ -141,7 +135,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c173192",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-10-02T20:34:08.360665Z",
@@ -196,7 +189,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25b45c6c",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-10-02T20:34:13.948100Z",
@@ -235,7 +227,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77e86f4e",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-10-02T20:34:15.477153Z",
@@ -264,7 +255,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35769c3d",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-10-02T20:34:17.137852Z",
@@ -282,7 +272,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0376a34c",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-10-02T20:34:18.224322Z",
@@ -321,7 +310,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2e102f3c",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-10-02T20:34:20.089418Z",
@@ -348,7 +336,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eb993978",
    "metadata": {},
    "source": [
     "## SKEMA Text Reading Functions"
@@ -357,7 +344,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b9fb799d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -387,7 +373,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e3641a86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -424,7 +409,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "751a0df1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -438,7 +422,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce91002e",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-29T20:25:21.317694Z",
@@ -451,7 +434,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e893165f",
    "metadata": {},
    "source": [
     "## Step 0: Indicate XDD identifier for input model source"
@@ -460,7 +442,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d5048c9f",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-10-02T20:34:22.774005Z",
@@ -474,7 +455,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4237e31c",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-29T20:24:49.281645Z",
@@ -488,7 +468,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c601ac5c",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-10-02T20:34:25.192128Z",
@@ -504,7 +483,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3b5f25b8",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-29T20:27:02.450824Z",
@@ -518,7 +496,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e2efcef7",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-10-02T20:34:28.385940Z",
@@ -536,7 +513,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15f7958a",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-29T20:27:56.308675Z",
@@ -551,8 +527,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "30e3dd80",
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-10-02T20:34:29.658742Z",
@@ -566,19 +541,12 @@
     "def get_mira_dkg_term(term, attribs):\n",
     "    res = requests.get(MIRA_DKG_URL + '/api/search', params={'q': term})\n",
     "    term = [entity for entity in res.json() if entity['id'].startswith('askemo')][0]\n",
-    "    res = {}\n",
-    "    for attrib, attrib_expand in attribs.items():\n",
-    "        if attrib_expand:\n",
-    "            for expand in attrib_expand:\n",
-    "                res[expand] = term.get(attrib, {}).get(expand, [None])[0]\n",
-    "        else:\n",
-    "            res[attrib] = term.get(attrib)\n",
+    "    res = {attrib: term.get(attrib) for attrib in attribs if term.get(attrib) is not None}\n",
     "    return res"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ed03657c",
    "metadata": {},
    "source": [
     "Next, we choose a set of terms and attributes to pull into a local ontology that we can use to connect to the model. In addition, for some of the terms, we define custom ranges in which their values for this model can be adjusted."
@@ -586,8 +554,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "a630d139",
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -598,19 +565,22 @@
        "  'xrefs': [{'id': 'ido:0000509', 'type': 'skos:exactMatch'}],\n",
        "  'suggested_unit': 'person',\n",
        "  'suggested_data_type': 'int',\n",
-       "  'min': 1000,\n",
-       "  'max': 40000000},\n",
+       "  'physical_min': 0.0,\n",
+       "  'typical_min': 1000,\n",
+       "  'typical_max': 40000000},\n",
        " 'doubling time': {'description': 'The length of time that an infectious disease requires to double in incidence.',\n",
        "  'synonyms': [{'value': 'doubling rate', 'type': 'skos:relatedMatch'}],\n",
        "  'xrefs': [{'id': 'cemo:epidemic_doubling_time', 'type': 'skos:exactMatch'}],\n",
        "  'suggested_unit': 'day',\n",
-       "  'suggested_data_type': 'float'},\n",
+       "  'suggested_data_type': 'float',\n",
+       "  'physical_min': 0.0},\n",
        " 'recovery time': {'description': 'The length of time an infected individual needs to recover after being infected.',\n",
        "  'synonyms': [{'value': 'mean recovery time', 'type': 'skos:exactMatch'},\n",
        "   {'value': 'recovery rate', 'type': 'skos:relatedMatch'}],\n",
        "  'xrefs': [],\n",
        "  'suggested_unit': 'day',\n",
-       "  'suggested_data_type': 'float'},\n",
+       "  'suggested_data_type': 'float',\n",
+       "  'physical_min': 0.0},\n",
        " 'infectious time': {'description': 'The length of time an infected individual is infectious after being infected.',\n",
        "  'synonyms': [{'value': 'contagious time', 'type': 'skos:exactMatch'},\n",
        "   {'value': 'infectious days', 'type': 'skos:narrowMatch'},\n",
@@ -618,11 +588,12 @@
        "  'xrefs': [{'id': 'apollosv:00000140', 'type': 'skos:exactMatch'}],\n",
        "  'suggested_unit': 'day',\n",
        "  'suggested_data_type': 'float',\n",
-       "  'min': 1,\n",
-       "  'max': 30}}"
+       "  'physical_min': 0.0,\n",
+       "  'typical_min': 1.0,\n",
+       "  'typical_max': 35.0}}"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -630,23 +601,23 @@
    "source": [
     "# Terms we want to find in MIRA and specific attributes we want to add to our local ontology\n",
     "terms = ['population', 'doubling time', 'recovery time', 'infectious time']\n",
-    "attribs = {'description': [], 'synonyms': [], 'xrefs': [], 'properties': ['suggested_unit', 'suggested_data_type']}\n",
+    "attribs = ['description', 'synonyms', 'xrefs', 'suggested_unit', 'suggested_data_type',\n",
+    "           'physical_min', 'physical_max', 'typical_min', 'typical_max']\n",
     "\n",
-    "PANDEMIC_ONTOLOGY = {\n",
+    "# The local ontology if filled up from the MIRA DKG\n",
+    "LOCAL_ONTOLOGY = {\n",
     "    term: get_mira_dkg_term(term, attribs) for term in terms\n",
     "    }\n",
     "\n",
-    "PANDEMIC_ONTOLOGY['population']['min'] = 1000\n",
-    "PANDEMIC_ONTOLOGY['population']['max'] = 40 * 1000 * 1000\n",
-    "PANDEMIC_ONTOLOGY['infectious time']['min'] = 1\n",
-    "PANDEMIC_ONTOLOGY['infectious time']['max'] = 30\n",
+    "# We can also set further local / use-case specific constraints as needed\n",
+    "LOCAL_ONTOLOGY['population']['typical_min'] = 1000\n",
+    "LOCAL_ONTOLOGY['population']['typical_max'] = 40_000_000\n",
     "\n",
-    "PANDEMIC_ONTOLOGY"
+    "LOCAL_ONTOLOGY"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f07284b1",
    "metadata": {},
    "source": [
     "## Step 4: Domain knowledge graph registration and indexing\n",
@@ -657,7 +628,6 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "0cb5ac20",
    "metadata": {},
    "outputs": [
     {
@@ -709,7 +679,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "766d6897",
    "metadata": {},
    "source": [
     "This knowledge graph is then indexed and projected into the literature -- currently via a naive term-based matching. This enables summarization of label volume across the xDD corpus (or subsets therein). The example below looks at the hyper-focused modeling-specific subset (more info in the next step), accumulating the number of mentions within the literature of each node label within the ingested DKG."
@@ -718,7 +687,6 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "c910aa57",
    "metadata": {},
    "outputs": [
     {
@@ -878,7 +846,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e5c13fa9",
    "metadata": {},
    "source": [
     "## Step 5: Literature queries and Relevant Corpus Definitions\n",
@@ -894,7 +861,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d6b4f672",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -905,7 +871,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0977929d",
    "metadata": {},
    "source": [
     "### Parameter exploration\n",
@@ -918,7 +883,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27d955ef",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -934,7 +898,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d83f150",
    "metadata": {},
    "source": [
     "Indicating that a recovery time of 1/γ = 14 days may be a reasonable starting point. However, the user can cast a wider net, and seek tables of relevant values from the very-focused modeling literature:"
@@ -943,7 +906,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d9eb2ff3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -959,7 +921,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd171069",
    "metadata": {},
    "source": [
     "Part of this response is a dataframe extraction of the discovered table, which may be useful for extraction (or ingestion into the workbench via the dataset cleanup/annotation process under development by Jataware:"
@@ -968,7 +929,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8757c92b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -978,7 +938,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "522b1ab6",
    "metadata": {},
    "source": [
     "## Step 6: [TODO] Possible Jataware table cleanup"
@@ -986,7 +945,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15aa5416",
    "metadata": {},
    "source": [
     "## Step 7: Perform machine reading of target paper (SKEMA Text Reading Pipeline), Grounding to concepts in the MIRA Epidemiology DKG"
@@ -995,7 +953,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7b23d37a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1008,7 +965,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e8a36cb5",
    "metadata": {},
    "source": [
     "## Step 8: Analyze Gromet FN model role analysis (SKEMA MORAE Module)\n",
@@ -1024,7 +980,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4eb27701",
    "metadata": {},
    "source": [
     "## Step 9: Analyze alignment of documentation equations to Gromet FN (SKEMA ISA Module)\n",
@@ -1038,7 +993,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a35d9c61",
    "metadata": {},
    "source": [
     "## Step 10: Analyze Gromet FN to identify beta parameter ranges that satisfy constraint (SKEMA FUNMAN)"
@@ -1046,7 +1000,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "338a06ec",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-29T20:29:23.510267Z",
@@ -1060,7 +1013,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51f49540",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-10-02T20:34:34.113531Z",
@@ -1078,7 +1030,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6e31a081",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-29T20:31:29.237903Z",
@@ -1092,7 +1043,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "822c7546",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-10-02T20:34:35.613934Z",
@@ -1107,11 +1057,11 @@
     "rows.append(widgets.HTML(\"<b>Recovered parameters</b>\"))\n",
     "for dpc in discoveredParameterConnections:\n",
     "    parameterName, grometObj, curValue, lineOfCode = dpc\n",
-    "    ontologyRecord = PANDEMIC_ONTOLOGY[parameterName]  # [\"parameters\"][parameterName]\n",
+    "    ontologyRecord = LOCAL_ONTOLOGY[parameterName]  # [\"parameters\"][parameterName]\n",
     "\n",
     "    currentKnobs[parameterName] = curValue\n",
-    "    curSlider = widgets.IntSlider(min=ontologyRecord[\"min\"], \n",
-    "                                     max=ontologyRecord[\"max\"], \n",
+    "    curSlider = widgets.IntSlider(min=ontologyRecord[\"typical_min\"], \n",
+    "                                     max=ontologyRecord[\"typical_max\"], \n",
     "                                     value=curValue)\n",
     "\n",
     "    sliders[parameterName] = curSlider\n",
@@ -1150,7 +1100,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "476d15b5",
    "metadata": {},
    "source": [
     "## Step 13: Update beta analysis to show difference based on model reparameterization (SKEMA FUNMAN)\n",
@@ -1160,7 +1109,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62ac55f3",
    "metadata": {},
    "source": [
     "## Step 14: When the user obtains an altered model she likes, she can choose to store it in XDD, along with metadata about how it was created\n",
@@ -1181,7 +1129,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d1ea51f2",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-10-02T20:34:41.512130Z",
@@ -1197,7 +1144,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -1211,7 +1158,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.9.9"
   },
   "varInspector": {
    "cols": {


### PR DESCRIPTION
This PR adapts the MIRA integration to the latest MIRA REST API which streamlines things. I also renamed the `PANDEMIC_ONTOLOGY` variable to `LOCAL_ONTOLOGY` which I think is better in this context.

Now, we get `typical_min` and `typical_max` values for `infectious time`. For `population` we add local/use case specific limits manually.